### PR TITLE
Implement chat method

### DIFF
--- a/lib/src/mistralai_client_dart_base.dart
+++ b/lib/src/mistralai_client_dart_base.dart
@@ -78,7 +78,9 @@ class MistralAIClient {
     final response = await _client
         .post(
           url,
-          body: _mapChatParamsToRequestParams(params, stream: false),
+          body: jsonEncode(
+            _mapChatParamsToRequestParams(params, stream: false),
+          ),
           headers: headers,
         )
         .timeout(timeout);

--- a/lib/src/mistralai_client_dart_base.dart
+++ b/lib/src/mistralai_client_dart_base.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'package:http/http.dart' as http;
 import 'package:http/retry.dart' as retry;
 import 'package:mistralai_client_dart/src/models/models.dart';
@@ -54,9 +55,65 @@ class MistralAIClient {
     }
   }
 
-  Future<ChatCompletion> chat(ChatParams params) {
-    throw UnimplementedError('to be implemented');
+  /// Returns a chat completion for given [params].
+  ///
+  /// Sends a request to
+  /// [Mistral AI API](https://docs.mistral.ai/api/#operation/createChatCompletion)
+  /// to create chat completions.
+  ///
+  /// Throws [MistralAIClientException] if the request fails.
+  Future<ChatCompletion> chat(ChatParams params) async {
+    final headers = {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer $apiKey',
+    };
+
+    // TODO(lgawron): endpoint building should be moved to separate class
+    // cleanup in https://github.com/nomtek/mistralai_client_dart/issues/13
+    final url = Uri.parse('$baseUrl/v1/chat/completions');
+
+    // TODO(lgawron): to add tests for this method we need to mock http client
+    // cleanup in https://github.com/nomtek/mistralai_client_dart/issues/13
+    final response = await _client
+        .post(
+          url,
+          body: _mapChatParamsToRequestParams(params, stream: false),
+          headers: headers,
+        )
+        .timeout(timeout);
+
+    // at the moment API docs are only telling about 200 status code
+    // no other status codes are mentioned or any specific errors
+    if (response.statusCode == 200) {
+      return ChatCompletion.fromJson(
+        jsonDecode(response.body) as Map<String, dynamic>,
+      );
+    } else {
+      // TODO(lgawron): Handle Json parsing errors
+      // TODO(lgwaron): Create custom client expcetions
+      // cleanup in https://github.com/nomtek/mistralai_client_dart/issues/13
+      throw MistralAIClientException(
+        'HTTP error! status: ${response.statusCode} '
+        'Response: \n${response.body}',
+      );
+    }
   }
+
+  ChatCompletionParams _mapChatParamsToRequestParams(
+    ChatParams params, {
+    required bool stream,
+  }) =>
+      ChatCompletionParams(
+        model: params.model,
+        messages: params.messages,
+        temperature: params.temperature,
+        topP: params.topP,
+        maxTokens: params.maxTokens,
+        stream: stream,
+        safeMode: params.safeMode,
+        randomSeed: params.randomSeed,
+      );
 
   Stream<ChatCompletion> streamChat(ChatParams params) {
     throw UnimplementedError('to be implemented');
@@ -65,4 +122,14 @@ class MistralAIClient {
   Future<Embeddings> embednings(EmbeddingParams params) {
     throw UnimplementedError('to be implemented');
   }
+}
+
+/// Simple exception class for Mistral AI Client exceptions.
+class MistralAIClientException implements Exception {
+  MistralAIClientException([this.message = '']);
+
+  final String message;
+
+  @override
+  String toString() => 'MistralAIClientException: $message';
 }

--- a/lib/src/models/chat_completion.dart
+++ b/lib/src/models/chat_completion.dart
@@ -9,12 +9,12 @@ class ChatCompletionParams {
   const ChatCompletionParams({
     required this.model,
     required this.messages,
-    required this.temperature,
-    required this.topP,
-    required this.maxTokens,
-    required this.stream,
-    required this.safeMode,
-    required this.randomSeed,
+    this.temperature,
+    this.topP,
+    this.maxTokens,
+    this.stream,
+    this.safeMode,
+    this.randomSeed,
   });
 
   factory ChatCompletionParams.fromJson(Map<String, dynamic> json) =>
@@ -22,16 +22,16 @@ class ChatCompletionParams {
 
   final String model;
   final List<Message> messages;
-  final double temperature;
+  final double? temperature;
   @JsonKey(name: 'top_p')
-  final int topP;
+  final double? topP;
   @JsonKey(name: 'max_tokens')
-  final int maxTokens;
-  final bool stream;
+  final int? maxTokens;
+  final bool? stream;
   @JsonKey(name: 'safe_mode')
-  final bool safeMode;
+  final bool? safeMode;
   @JsonKey(name: 'random_seed')
-  final dynamic randomSeed;
+  final int? randomSeed;
 
   Map<String, dynamic> toJson() => _$ChatCompletionParamsToJson(this);
 }

--- a/lib/src/models/chat_completion.g.dart
+++ b/lib/src/models/chat_completion.g.dart
@@ -13,12 +13,12 @@ ChatCompletionParams _$ChatCompletionParamsFromJson(
       messages: (json['messages'] as List<dynamic>)
           .map((e) => Message.fromJson(e as Map<String, dynamic>))
           .toList(),
-      temperature: (json['temperature'] as num).toDouble(),
-      topP: json['top_p'] as int,
-      maxTokens: json['max_tokens'] as int,
-      stream: json['stream'] as bool,
-      safeMode: json['safe_mode'] as bool,
-      randomSeed: json['random_seed'],
+      temperature: (json['temperature'] as num?)?.toDouble(),
+      topP: (json['top_p'] as num?)?.toDouble(),
+      maxTokens: json['max_tokens'] as int?,
+      stream: json['stream'] as bool?,
+      safeMode: json['safe_mode'] as bool?,
+      randomSeed: json['random_seed'] as int?,
     );
 
 Map<String, dynamic> _$ChatCompletionParamsToJson(

--- a/lib/src/models/chat_params.dart
+++ b/lib/src/models/chat_params.dart
@@ -1,23 +1,37 @@
 import 'package:meta/meta.dart';
 import 'package:mistralai_client_dart/src/models/chat_completion.dart';
 
+/// Params are referring to params from official
+/// [Mistral AI API docs](https://docs.mistral.ai/api/#operation/createChatCompletion)
 @immutable
 class ChatParams {
   const ChatParams({
     required this.model,
     required this.messages,
-    required this.temperature,
-    required this.topP,
-    required this.maxTokens,
-    required this.safeMode,
-    required this.randomSeed,
-  });
+    this.temperature,
+    this.topP,
+    this.maxTokens,
+    this.safeMode,
+    this.randomSeed,
+  })  : assert(messages.length > 0, 'messages cannot be empty'),
+        assert(
+          temperature == null || (temperature >= 0 && temperature <= 1),
+          'temperature must be between 0 and 1',
+        ),
+        assert(
+          topP == null || (topP >= 0 && topP <= 1),
+          'topP must be between 0 and 1',
+        ),
+        assert(
+          maxTokens == null || maxTokens >= 0,
+          'maxTokens must be greater or equal to 0',
+        );
 
   final String model;
   final List<Message> messages;
-  final double temperature;
-  final int topP;
-  final int maxTokens;
-  final bool safeMode;
-  final dynamic randomSeed;
+  final double? temperature;
+  final double? topP;
+  final int? maxTokens;
+  final bool? safeMode;
+  final int? randomSeed;
 }

--- a/test/src/models/chat_params_test.dart
+++ b/test/src/models/chat_params_test.dart
@@ -1,0 +1,76 @@
+import 'package:mistralai_client_dart/src/models/models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('throws assert exception when trying to create ChatParams', () {
+    test('with empty messages', () {
+      expect(
+        () => chatParamsOf(messages: const []),
+        throwsA(isA<AssertionError>()),
+        reason: 'Should throw AssertionError when messages is empty',
+      );
+    });
+
+    final temparatureInvalidValues = <double>[-1, -0.1, 1.1, 2];
+    for (final value in temparatureInvalidValues) {
+      test('with temperature outside 0-1 range (value: $value)', () {
+        expect(
+          () => chatParamsOf(temperature: value),
+          throwsA(isA<AssertionError>()),
+          reason:
+              'Should throw AssertionError when temperature is not in range 0-1'
+              ' for value: $value',
+        );
+      });
+    }
+
+    final topPInvalidValues = <double>[-1, -0.1, 1.1, 2];
+    for (final value in topPInvalidValues) {
+      test('with topP outside 0-1 range (value: $value)', () {
+        expect(
+          () => chatParamsOf(topP: value),
+          throwsA(isA<AssertionError>()),
+          reason: 'Should throw AssertionError when topP is not in range 0-1 '
+              'for value: $value',
+        );
+      });
+    }
+
+    test('with maxTokens less than 0', () {
+      expect(
+        () => chatParamsOf(maxTokens: -1),
+        throwsA(isA<AssertionError>()),
+        reason: 'Should throw AssertionError when maxTokens is less than 0',
+      );
+    });
+  });
+}
+
+Message messageOf({
+  String? role,
+  String? content,
+}) =>
+    Message(
+      role: role ?? 'role',
+      content: content ?? 'content',
+    );
+
+// creates ChatParams with default values for tests
+ChatParams chatParamsOf({
+  String? model,
+  List<Message>? messages,
+  double? temperature,
+  double? topP,
+  int? maxTokens,
+  bool? safeMode,
+  int? randomSeed,
+}) =>
+    ChatParams(
+      model: model ?? 'model',
+      messages: messages ?? [messageOf()],
+      temperature: temperature,
+      topP: topP,
+      maxTokens: maxTokens,
+      safeMode: safeMode,
+      randomSeed: randomSeed,
+    );


### PR DESCRIPTION
resolves https://github.com/nomtek/mistralai_client_dart/issues/5

- adds an implementation of `MistralAIClient.chat`
- fixes wrong Chat params types - not matching official API
- adds assertions to `ChatParams` with unit tests
- introduces `MistralAIClientException` to represent exceptions of `MistralAIClient`
