### PR TITLE
Add `toolCallId` to ChatMessage and make it mandatory when using tool messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,30 +116,35 @@ var chatResponse = await client.chat(
 
 final toolCall = chatResponse.choices[0].message.toolCalls?[0];
 if (toolCall != null && toolCall.type == 'function') {
-    final functionName = toolCall.function!.name;
-    final functionParams = toolCall.function!.argumentsMap;
+  final functionName = toolCall.function!.name;
+  final functionParams = toolCall.function!.argumentsMap;
 
-    print('calling functionName: $functionName');
-    print('functionParams: $functionParams');
+  print('calling functionName: $functionName');
+  print('functionParams: $functionParams');
 
-    final functionResult = namesToFunctions[functionName]!(
-        functionParams['transactionId']! as String,
-    );
+  final functionResult = namesToFunctions[functionName]!(
+      functionParams['transactionId']! as String,
+  );
 
-    messages.add(
-        ChatMessage(role: 'tool', content: functionResult, name: functionName),
-    );
+  messages.add(
+    ChatMessage(
+      role: 'tool',
+      content: functionResult,
+      name: functionName,
+      toolCallId: toolCall.id,
+    ),
+  );
 
-    chatResponse = await client.chat(
-        ChatParams(
-            model: model,
-            messages: messages,
-            tools: tools,
-            toolChoice: 'auto',
-        ),
-    );
+  chatResponse = await client.chat(
+      ChatParams(
+          model: model,
+          messages: messages,
+          tools: tools,
+          toolChoice: 'auto',
+      ),
+  );
 
-    print(chatResponse.choices[0].message.content);
+  print(chatResponse.choices[0].message.content);
 }
 ```
 

--- a/example/mistralai_client_function_calling_dart_example.dart
+++ b/example/mistralai_client_function_calling_dart_example.dart
@@ -121,7 +121,12 @@ void main() async {
   );
 
   messages.add(
-    ChatMessage(role: 'tool', content: functionResult, name: functionName),
+    ChatMessage(
+      role: 'tool',
+      content: functionResult,
+      name: functionName,
+      toolCallId: toolCall.id,
+    ),
   );
 
   chatResponse = await client.chat(

--- a/lib/src/models/chat_completion.dart
+++ b/lib/src/models/chat_completion.dart
@@ -66,7 +66,11 @@ class ChatMessage {
     required this.content,
     this.name,
     this.toolCalls,
-  });
+    this.toolCallId,
+  }) : assert(
+          (role == 'tool' && toolCallId != null) || role != 'tool',
+          'toolCallId is required when role is tool',
+        );
 
   factory ChatMessage.fromJson(Map<String, dynamic> json) =>
       _$ChatMessageFromJson(json);
@@ -76,12 +80,15 @@ class ChatMessage {
   final String? name;
   @JsonKey(name: 'tool_calls')
   final List<ToolCall>? toolCalls;
+  @JsonKey(name: 'tool_call_id')
+  final String? toolCallId;
 
   Map<String, dynamic> toJson() => _$ChatMessageToJson(this);
 
   @override
-  String toString() => 'ChatMessage{role: $role, content: $content, '
-      'name: $name, toolCalls: $toolCalls}';
+  String toString() =>
+      'ChatMessage{role: $role, content: $content, name: $name, '
+      'toolCalls: $toolCalls, toolCallId: $toolCallId}';
 }
 
 /// Represents a chat completion result.

--- a/lib/src/models/chat_completion.g.dart
+++ b/lib/src/models/chat_completion.g.dart
@@ -60,6 +60,7 @@ ChatMessage _$ChatMessageFromJson(Map<String, dynamic> json) => ChatMessage(
       toolCalls: (json['tool_calls'] as List<dynamic>?)
           ?.map((e) => ToolCall.fromJson(e as Map<String, dynamic>))
           .toList(),
+      toolCallId: json['tool_call_id'] as String?,
     );
 
 Map<String, dynamic> _$ChatMessageToJson(ChatMessage instance) {
@@ -76,6 +77,7 @@ Map<String, dynamic> _$ChatMessageToJson(ChatMessage instance) {
 
   writeNotNull('name', instance.name);
   writeNotNull('tool_calls', instance.toolCalls);
+  writeNotNull('tool_call_id', instance.toolCallId);
   return val;
 }
 

--- a/test/src/common_tests.dart
+++ b/test/src/common_tests.dart
@@ -210,7 +210,7 @@ dynamic testIfRequestUrlIsCorrect<T>({
 /// [clientRequest] - function that calls API method
 ///
 /// [bodyParams] - body params that should be sent
-dynamic testIfProperBodyParamsAreSent<T>({
+Future<void> testIfProperBodyParamsAreSent<T>({
   required String apiJsonResponseBody,
   required Future<T> Function(
     MistralAIClient client,

--- a/test/src/mistralai_client_dart_base_chat_test.dart
+++ b/test/src/mistralai_client_dart_base_chat_test.dart
@@ -25,7 +25,7 @@ void main() {
         final chatJsonParams = jsonDecode(chatCompletionParamsWithAllFieldsBody)
             as Map<String, dynamic>;
 
-        testIfProperBodyParamsAreSent(
+        await testIfProperBodyParamsAreSent(
           apiJsonResponseBody: chatCompletionResponse,
           clientRequest: (client, bodyParams) =>
               client.chat(chatParamsWithAllFields),
@@ -37,12 +37,12 @@ void main() {
     test(
       'calling chat with required params '
       'should result in sending required params in request body',
-      () {
+      () async {
         final chatJsonParams =
             jsonDecode(chatCompletionParamsWithRequiredFieldsBody)
                 as Map<String, dynamic>;
 
-        testIfProperBodyParamsAreSent(
+        await testIfProperBodyParamsAreSent(
           apiJsonResponseBody: chatCompletionResponse,
           clientRequest: (client, bodyParams) =>
               client.chat(chatParamsWithRequiredFields),
@@ -232,6 +232,7 @@ ChatParams chatParamsWithAllFields = ChatParams(
       role: 'user',
       content: 'What is the best French cheese?',
       name: 'toolFunction',
+      toolCallId: 'toolCallId',
     ),
   ],
   temperature: 0.7,
@@ -263,7 +264,8 @@ const chatCompletionParamsWithAllFieldsBody = '''
     {
       "role": "user",
       "content": "What is the best French cheese?",
-      "name": "toolFunction"
+      "name": "toolFunction",
+      "tool_call_id": "toolCallId"
     }
   ],
   "temperature": 0.7,

--- a/test/src/mistralai_client_dart_base_embeddings_test.dart
+++ b/test/src/mistralai_client_dart_base_embeddings_test.dart
@@ -25,7 +25,7 @@ void main() {
         final embeddingJsonParams =
             jsonDecode(embeddingsParamsBody) as Map<String, dynamic>;
 
-        testIfProperBodyParamsAreSent(
+        await testIfProperBodyParamsAreSent(
           apiJsonResponseBody: embeddingsResponse,
           clientRequest: (client, bodyParams) =>
               client.embeddings(embedingsParams),

--- a/test/src/models/chat_message_test.dart
+++ b/test/src/models/chat_message_test.dart
@@ -1,0 +1,17 @@
+import 'package:mistralai_client_dart/mistralai_client_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ChatMessage', () {
+    test('toolCallId is mandatory when role is tool', () {
+      expect(
+        () => ChatMessage(
+          role: 'tool',
+          name: 'function-name',
+          content: 'tool call result',
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
### Description

Comply with the Mistral AI API and add `tool_call_id` to `ChatMessage`.

### Issue

Closes #49 

### Changes Made

- add `toolCallId` with assert to `ChatMessage` class

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/nomtek/mistralai_client_dart/blob/main/CONTRIBUTING.md) document.
- [x] I have tested my changes.
- [x] I have added/updated documentation accordingly.
