### PR TITLE
feat: Add automated publish to pub.dev workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,15 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      # must align with the tag-pattern configured on pub.dev
+      - '[0-9]+.[0-9]+.[0-9]+*' # tag-pattern on pub.dev: '{{version}}'
+
+# Based on official guide from https://dart.dev/tools/pub/automated-publishing
+jobs:
+  publish:
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    # Publish using the reusable workflow from dart-lang.
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1

--- a/docs/releases/Package-Release-Process.md
+++ b/docs/releases/Package-Release-Process.md
@@ -17,9 +17,7 @@ When releasing the main package version we should also release the FlutterFlow v
    - Auto generate release notes (adjust the releases notes if needed)
    - Set title of release to the name of version. For example if we want to release version 1.0.0 then release title should be `1.0.0`.
    - Publish release.
-3. Publish the package to [pub.dev](https://pub.dev)
-   - checkout tag that was created in step 5.
-   - run `dart pub publish` from the (you have to be logged in to pub.dev and have access to publishing to the package).
+   - The [publish workflow](../../.github/workflows/publish.yaml) will automatically run after the new tag is pushed to the repository and publish the new package version to [pub.dev](https://pub.dev/packages/mistralai_client_dart).
 
 ### FlutterFlow version
 


### PR DESCRIPTION
### Description

Introduced an automatic workflow that publishes the package to pub.dev. Now the release of a new version can be done by any of the maintainers and doesn't require someone with access to the pub.dev account.

### Issue

Closes #21

### Changes Made

- Added a new workflow that will automatically publish a new SDK version after a new tag is pushed.

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/nomtek/mistralai_client_dart/blob/main/CONTRIBUTING.md) document.
- [x] I have tested my changes.
- [x] I have added/updated documentation accordingly.
